### PR TITLE
[GOSAC-1117] - (CLONE SUP-1272) Lid is missing in chat table - jvadvmilitar

### DIFF
--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -575,9 +575,21 @@ exports.LoadUtils = () => {
                 chat = null;
             }
         } else {
-            chat = window.Store.Chat.get(chatWid) || (await window.Store.FindOrCreateChat.findOrCreateLatestChat(chatWid))?.chat;
+            chat = await window.Store.FindOrCreateChat.findOrCreateLatestChat(chatWid)
+              .then(chat => chat.chat)
+              .catch(async err => {
+                let query = window.require("WAWebContactSyncUtils").constructUsyncDeltaQuery([{
+                  type: "add",
+                  phoneNumber: chatWid.user
+                }]);
+                  
+                let result =  await query.execute();
+                if (result && Array.isArray(result.list) &&result.list.length > 0 &&result.list[0] &&result.list[0].lid) {
+                  chatLid = window.Store.WidFactory.createWid(result.list[0].lid)
+                  return await window.require('WAWebFindChatAction').findOrCreateLatestChat(chatLid).then(chat => chat.chat).catch(async err => null)
+                }
+              })
         }
-
         return getAsModel && chat
             ? await window.WWebJS.getChatModel(chat, { isChannel: isChannel })
             : chat;


### PR DESCRIPTION
# 🖥️ (CLONE SUP-1272) Lid is missing in chat table - jvadvmilitar
Atualizada função ``window.WWebJS.getChat`` para: 
- Utilizar apenas a função ``window.Store.FindOrCreateChat.findOrCreateLatestChat`` para obter o chat, já que alguns problemas com a obtenção do Lid vinham da outra função ``window.Store.Chat.get`` utilizada primariamente;
- Adicionar o contato quando ele não existir para tornar possível a obtenção do Lid para envio de mensagem.

Correção modelada a partir do apontado na [issue #3834](https://github.com/pedroslopez/whatsapp-web.js/issues/3834#issuecomment-3724237369)

### 📃 Links
[[Jira]](https://leeksolucoes.atlassian.net/browse/GOSAC-1117)

### Issues
- [ ] feat
- [x] fix
- [ ] ci
- [ ] remove
- [ ] refactor

### 🧪 Onde você testou?
- [x] Chrome
- [ ] Safari
- [ ] Firefox

### 📁 Arquivos manipulados
``src/util/Injected/Utils.js``